### PR TITLE
replace version of gradle dependency in README as 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Add the following to your dependencies:
 
 ```groovy
 testCompile 'com.github.tomakehurst:wiremock:2.21.0'
-testCompile 'org.wiremock:wiremock-webhooks-extension:1.0.2'
+testCompile 'org.wiremock:wiremock-webhooks-extension:1.0.0'
 ```
 
 ## Using in your project


### PR DESCRIPTION
1.0.0 is latest version of extension that is available in mvn repository, using 1.0.2 in example was confusing