### PR TITLE
support multiple webhooks

### DIFF
--- a/src/main/java/org/wiremock/webhooks/WebhookDefinitionBuilder.java
+++ b/src/main/java/org/wiremock/webhooks/WebhookDefinitionBuilder.java
@@ -1,0 +1,19 @@
+package org.wiremock.webhooks;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class WebhookDefinitionBuilder {
+    private List<WebhookDefinition> webhooks = new ArrayList<>();
+
+    public WebhookDefinitionBuilder addWebhook(WebhookDefinition webhookDefinition) {
+        webhooks.add(webhookDefinition);
+        return this;
+    }
+
+    public WebhookDefinitionContainer build() {
+        return new WebhookDefinitionContainer(ImmutableList.copyOf(webhooks));
+    }
+}

--- a/src/main/java/org/wiremock/webhooks/WebhookDefinitionContainer.java
+++ b/src/main/java/org/wiremock/webhooks/WebhookDefinitionContainer.java
@@ -1,0 +1,20 @@
+package org.wiremock.webhooks;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+public class WebhookDefinitionContainer {
+    private List<WebhookDefinition> webhooks;
+
+    @JsonCreator
+    public WebhookDefinitionContainer(@JsonProperty("webhooks") List<WebhookDefinition> webhooks) {
+        this.webhooks = webhooks;
+    }
+
+    public List<WebhookDefinition> getWebhooks() {
+        return ImmutableList.copyOf(webhooks);
+    }
+}


### PR DESCRIPTION
Proposal for issue: [GH-11](https://github.com/wiremock/wiremock-webhooks-extension/issues/11)

Defining multiple webhooks is possible via json config like
```json
{
  "request" : {
    "urlPath" : "/something-async",
    "method" : "POST"
  },
  "response" : {
    "status" : 200
  },
  "postServeActions" : {
    "webhooks" : {
      "webhooks": [
        {
          "headers" : {
            "Content-Type" : "application/json"
          },
          "method" : "POST",
          "body" : "{ \"result\": \"SUCCESS\" }",
          "url" : "http://localhost:56299/callback"
        },
        {
          "headers" : {
            "Content-Type" : "application/json"
          },
          "method" : "POST",
          "body" : "{ \"result\": \"SUCCESS AGAIN\" }",
          "url" : "http://localhost:56299/callback"
        }
      ]
  }
}
```
happy to change names @tomakehurst since I realize we are stating ```webhooks``` twice here. 

This pr also assumes that webhooks are always ordered. I think that makes sense, and if the API under test delivers these async.. then I think a separate stub definition should be defined. 

Two follow ups I see from here are:
- how do transformers work per webhook
- how do we want to simulate delays between the hooks? maybe we add another field in ```WebhookDefinition``` to captures the delay like ```private Duration waitFor;``` 