### PR TITLE
optionally define a delay in webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ You can also use JSON to configure webhooks:
       },
       "method" : "POST",
       "body" : "{ \"result\": \"SUCCESS\" }",
-      "url" : "http://localhost:56299/callback"
+      "url" : "http://localhost:56299/callback",
+      "delay" : 1000
     }
   }
 }
@@ -101,7 +102,9 @@ System.out.println(Json.write(post(urlPathEqualTo("/something"))
         .withMethod(POST)
         .withUrl("http://localhost:" + targetServer.port() + "/callback")
         .withHeader("Content-Type", "application/json")
-        .withBody("{ \"result\": \"SUCCESS\" }")).build()
+        .withBody("{ \"result\": \"SUCCESS\" }"))
+        .withDelay(1_000)  // in milliseconds
+        .build()
     )
 );
 ```

--- a/src/main/java/org/wiremock/webhooks/WebhookDefinition.java
+++ b/src/main/java/org/wiremock/webhooks/WebhookDefinition.java
@@ -19,17 +19,20 @@ public class WebhookDefinition {
     private URI url;
     private List<HttpHeader> headers;
     private Body body = Body.none();
+    private long delay; // delay in webhook expressed in milliseconds
 
     @JsonCreator
     public WebhookDefinition(@JsonProperty("method") RequestMethod method,
                              @JsonProperty("url") URI url,
                              @JsonProperty("headers") HttpHeaders headers,
                              @JsonProperty("body") String body,
-                             @JsonProperty("base64Body") String base64Body) {
+                             @JsonProperty("base64Body") String base64Body,
+                             @JsonProperty(value = "delay", defaultValue = "0") long delay) {
         this.method = method;
         this.url = url;
         this.headers = newArrayList(headers.all());
         this.body = Body.fromOneOf(null, body, null, base64Body);
+        this.delay = delay;
     }
 
     public WebhookDefinition() {
@@ -53,6 +56,10 @@ public class WebhookDefinition {
 
     public String getBody() {
         return body.isBinary() ? null : body.asString();
+    }
+
+    public long getDelay(){
+        return delay;
     }
 
     @JsonIgnore
@@ -96,6 +103,11 @@ public class WebhookDefinition {
 
     public WebhookDefinition withBinaryBody(byte[] body) {
         this.body = new Body(body);
+        return this;
+    }
+
+    public WebhookDefinition withDelay(long delay){
+        this.delay = delay;
         return this;
     }
 }

--- a/src/test/java/functional/JsonTest.java
+++ b/src/test/java/functional/JsonTest.java
@@ -1,0 +1,48 @@
+package functional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Before;
+import org.junit.Test;
+import org.wiremock.webhooks.WebhookDefinition;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class JsonTest {
+
+    private ObjectMapper objectMapper;
+
+    @Before
+    public void setup() {
+        objectMapper = new ObjectMapper();
+    }
+
+    @Test
+    public void webhookWithNoDelay() throws IOException {
+        WebhookDefinition webhookDefinition = objectMapper.readValue("{\n" +
+                "      \"headers\" : {\n" +
+                "        \"Content-Type\" : \"application/json\"\n" +
+                "      },\n" +
+                "      \"method\" : \"POST\",\n" +
+                "      \"body\" : \"{ \\\"result\\\": \\\"SUCCESS\\\" }\",\n" +
+                "      \"url\" : \"http://localhost:56299/callback\"\n" +
+                "    }", WebhookDefinition.class);
+        assertThat("delay is defaulted to 0", webhookDefinition.getDelay(), is(0L));
+    }
+
+    @Test
+    public void webhookWithDelay() throws IOException {
+        WebhookDefinition webhookDefinition = objectMapper.readValue("{\n" +
+                "      \"headers\" : {\n" +
+                "        \"Content-Type\" : \"application/json\"\n" +
+                "      },\n" +
+                "      \"delay\": 1000,\n" +
+                "      \"method\" : \"POST\",\n" +
+                "      \"body\" : \"{ \\\"result\\\": \\\"SUCCESS\\\" }\",\n" +
+                "      \"url\" : \"http://localhost:56299/callback\"\n" +
+                "    }", WebhookDefinition.class);
+        assertThat("delay can be optionally set", webhookDefinition.getDelay(), is(1_000L));
+    }
+}


### PR DESCRIPTION
A follow up from the discussion on https://github.com/wiremock/wiremock-webhooks-extension/pull/20

This change adds a delay parameter to the webhook definition. Thanks for the feedback @tomakehurst, I also would have preferred ```java.time.Duration``` but that would have required java 8+ and wasn't convinced this should be the reason to force the new version. Instead, a delay in milliseconds should reasonably cover any latency you would expect in a test.